### PR TITLE
Fix broken regex replace for image URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', function () {
         document.documentElement.innerHTML = originHtml;
         
         if (css) {
-            css = css.replace(/\/\/ssl.gstatic./g, 'https://ssl.gstatic.');
+            css = css.replace(/'\/\/ssl\.gstatic/g, "'https://ssl.gstatic");
             document.getElementById('loadcss').innerHTML = css;
         }
         


### PR DESCRIPTION
Hi,

I noticed a bug that prevented some of the icon images from being loaded. I've submitted a pull request.

Please see attached image to understand the problem.

Thanks,
Nathan

<img width="1097" alt="screen shot 2018-07-14 at 8 20 27 pm" src="https://user-images.githubusercontent.com/1323414/42727788-579a0eb0-87b5-11e8-92fe-e8e92e2202bd.png">
